### PR TITLE
FEAT: 관리자 회원관리 API 구현 (목록/상세/수정/생성)

### DIFF
--- a/src/main/java/com/example/moyeorak/config/SecurityConfig.java
+++ b/src/main/java/com/example/moyeorak/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**", "/swagger-ui.html",
                                 "/v3/api-docs/**", "/v3/api-docs.yaml"
                         ).permitAll()
+                        .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
@@ -1,4 +1,5 @@
 package com.example.moyeorak.controller.admin;
+import com.example.moyeorak.dto.admin.AdminUserDetailResponseDto;
 
 import com.example.moyeorak.dto.admin.AdminUserCreateRequestDto;
 import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
@@ -35,5 +36,15 @@ public class AdminUserController {
     ) {
         adminUserService.createUser(dto, request);
         return ResponseEntity.ok().build();
+    }
+
+    // 회원 상세 정보 조회
+    @GetMapping("/{userId}")
+    public ResponseEntity<AdminUserDetailResponseDto> getUserDetail(
+            @PathVariable Long userId,
+            HttpServletRequest request
+    ) {
+        AdminUserDetailResponseDto userDetail = adminUserService.getUserDetail(userId, request);
+        return ResponseEntity.ok(userDetail);
     }
 }

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
@@ -3,6 +3,7 @@ import com.example.moyeorak.dto.admin.AdminUserDetailResponseDto;
 
 import com.example.moyeorak.dto.admin.AdminUserCreateRequestDto;
 import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
+import com.example.moyeorak.dto.admin.AdminUserUpdateRequestDto;
 import com.example.moyeorak.service.admin.AdminUserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -46,5 +47,15 @@ public class AdminUserController {
     ) {
         AdminUserDetailResponseDto userDetail = adminUserService.getUserDetail(userId, request);
         return ResponseEntity.ok(userDetail);
+    }
+
+    // 회원정보수정
+    @PatchMapping("/{userId}")
+    public ResponseEntity<Void> updateUserInfo(
+            @PathVariable Long userId,
+            @RequestBody AdminUserUpdateRequestDto dto
+    ) {
+        adminUserService.updateUserInfo(userId, dto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -17,9 +18,12 @@ public class AdminUserController {
 
     private final AdminUserService adminUserService;
 
-    // ✅ AccessToken 기반으로 관리자 유저 식별
+    // AccessToken 기반으로 관리자 유저 식별, null이면 자기 지역 값 있으면 그 지역 뜨게
     @GetMapping
-    public List<AdminUserListResponseDto> getUsersByRegion(HttpServletRequest request) {
-        return adminUserService.getUsersByRegionFromToken(request);
+    public List<AdminUserListResponseDto> getUsersByRegion(
+            @RequestParam(required = false) Long regionId,
+            HttpServletRequest request
+    ) {
+        return adminUserService.getUsersByRegion(request, regionId);
     }
 }

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
@@ -1,13 +1,12 @@
 package com.example.moyeorak.controller.admin;
 
+import com.example.moyeorak.dto.admin.AdminUserCreateRequestDto;
 import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
 import com.example.moyeorak.service.admin.AdminUserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,5 +25,15 @@ public class AdminUserController {
             HttpServletRequest request
     ) {
         return adminUserService.getUsersByRegionAndKeyword(request, regionId, keyword);
+    }
+
+    // 유저 생성
+    @PostMapping
+    public ResponseEntity<Void> createUser(
+            @RequestBody AdminUserCreateRequestDto dto,
+            HttpServletRequest request
+    ) {
+        adminUserService.createUser(dto, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
@@ -2,24 +2,24 @@ package com.example.moyeorak.controller.admin;
 
 import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
 import com.example.moyeorak.service.admin.AdminUserService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin/users") // 관리자용 유저 API 경로
+@RequestMapping("/api/admin/users")
 public class AdminUserController {
 
     private final AdminUserService adminUserService;
 
-    // 관리자 담당 지역의 유저 리스트 조회
+    // ✅ AccessToken 기반으로 관리자 유저 식별
     @GetMapping
-    public List<AdminUserListResponseDto> getUsersByRegion(@RequestParam Long adminId) {
-        return adminUserService.getUsersByRegion(adminId);
+    public List<AdminUserListResponseDto> getUsersByRegion(HttpServletRequest request) {
+        return adminUserService.getUsersByRegionFromToken(request);
     }
 }

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
@@ -1,0 +1,25 @@
+package com.example.moyeorak.controller.admin;
+
+import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
+import com.example.moyeorak.service.admin.AdminUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/users") // 관리자용 유저 API 경로
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    // 관리자 담당 지역의 유저 리스트 조회
+    @GetMapping
+    public List<AdminUserListResponseDto> getUsersByRegion(@RequestParam Long adminId) {
+        return adminUserService.getUsersByRegion(adminId);
+    }
+}

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
@@ -4,6 +4,7 @@ import com.example.moyeorak.dto.admin.AdminUserDetailResponseDto;
 import com.example.moyeorak.dto.admin.AdminUserCreateRequestDto;
 import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
 import com.example.moyeorak.dto.admin.AdminUserUpdateRequestDto;
+import com.example.moyeorak.dto.admin.AdminPasswordUpdateRequestDto;
 import com.example.moyeorak.service.admin.AdminUserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -56,6 +57,16 @@ public class AdminUserController {
             @RequestBody AdminUserUpdateRequestDto dto
     ) {
         adminUserService.updateUserInfo(userId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    // 비밀번호 수정
+    @PatchMapping("/{userId}/password")
+    public ResponseEntity<Void> updateUserPassword(
+            @PathVariable Long userId,
+            @RequestBody AdminPasswordUpdateRequestDto dto
+    ) {
+        adminUserService.updateUserPassword(userId, dto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminUserController.java
@@ -20,10 +20,11 @@ public class AdminUserController {
 
     // AccessToken 기반으로 관리자 유저 식별, null이면 자기 지역 값 있으면 그 지역 뜨게
     @GetMapping
-    public List<AdminUserListResponseDto> getUsersByRegion(
+    public List<AdminUserListResponseDto> getUsersByRegionAndKeyword(
             @RequestParam(required = false) Long regionId,
+            @RequestParam(required = false) String keyword,
             HttpServletRequest request
     ) {
-        return adminUserService.getUsersByRegion(request, regionId);
+        return adminUserService.getUsersByRegionAndKeyword(request, regionId, keyword);
     }
 }

--- a/src/main/java/com/example/moyeorak/dto/admin/AdminPasswordUpdateRequestDto.java
+++ b/src/main/java/com/example/moyeorak/dto/admin/AdminPasswordUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.moyeorak.dto.admin;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminPasswordUpdateRequestDto {
+    private String newPassword;
+    private String confirmPassword;
+}

--- a/src/main/java/com/example/moyeorak/dto/admin/AdminUserCreateRequestDto.java
+++ b/src/main/java/com/example/moyeorak/dto/admin/AdminUserCreateRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.moyeorak.dto.admin;
+
+import lombok.Data;
+
+@Data
+public class AdminUserCreateRequestDto {
+    private String email;
+    private String password;
+    private String name;
+    private String gender; // "남" 또는 "여"
+    private String birth;  // yyyy-MM-dd 형식
+    private String phone;
+}

--- a/src/main/java/com/example/moyeorak/dto/admin/AdminUserDetailResponseDto.java
+++ b/src/main/java/com/example/moyeorak/dto/admin/AdminUserDetailResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.moyeorak.dto.admin;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminUserDetailResponseDto {
+    private Long id;
+    private String name;         // 읽기 전용
+    private String gender;       // 읽기 전용 ("남"/"여")
+    private String createdAt;    // 가입일 (yyyy.MM.dd)
+
+    private String email;        // 수정 가능
+    private String phone;        // 수정 가능
+    private Long regionId;       // 현재 지역 ID (수정 가능)
+    private String regionName;   // 지역 이름 (예: "송파구") → 화면 표시용
+}

--- a/src/main/java/com/example/moyeorak/dto/admin/AdminUserListResponseDto.java
+++ b/src/main/java/com/example/moyeorak/dto/admin/AdminUserListResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.moyeorak.dto.admin;
+
+import com.example.moyeorak.entity.User;
+
+import java.time.format.DateTimeFormatter;
+
+public record AdminUserListResponseDto(
+        Long id,
+        String name,
+        String gender,
+        String email,
+        String region,
+        String createdAt
+) {
+    public static AdminUserListResponseDto from(User user) {
+        return new AdminUserListResponseDto(
+                user.getId(),
+                user.getName(),
+                user.getGender().name(),  // enum이면 .name()으로 꺼내기
+                user.getEmail(),
+                user.getRegion().getName(), // Address 엔티티에서 지역 이름 추출
+                user.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")) // 가입일 포맷
+        );
+    }
+}

--- a/src/main/java/com/example/moyeorak/dto/admin/AdminUserUpdateRequestDto.java
+++ b/src/main/java/com/example/moyeorak/dto/admin/AdminUserUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.moyeorak.dto.admin;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminUserUpdateRequestDto {
+    private String email;
+    private String phone;
+    private Long regionId; // 거주지 region은 ID로 받아서 처리
+}

--- a/src/main/java/com/example/moyeorak/jwt/JwtProvider.java
+++ b/src/main/java/com/example/moyeorak/jwt/JwtProvider.java
@@ -3,6 +3,7 @@ package com.example.moyeorak.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -85,4 +86,15 @@ public class JwtProvider {
                 .parseClaimsJws(token)
                 .getBody();
     }
+
+    //  "Authorization: Bearer abc.def.ghi" 형식에서 "abc.def.ghi"만 뽑아주는 역할
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
 }
+
+

--- a/src/main/java/com/example/moyeorak/repository/UserRepository.java
+++ b/src/main/java/com/example/moyeorak/repository/UserRepository.java
@@ -11,4 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByPhone(String phone);
     List<User> findByRegion(Region region);
+
+    // 회원조회할때 user만 보이게
+    List<User> findByRegionAndRole(Region region, User.Role role);
 }

--- a/src/main/java/com/example/moyeorak/repository/UserRepository.java
+++ b/src/main/java/com/example/moyeorak/repository/UserRepository.java
@@ -14,4 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 회원조회할때 user만 보이게
     List<User> findByRegionAndRole(Region region, User.Role role);
+
+    // region, role, 이름(검색어) 포함(대소문자 무시) 조건으로 유저 필터링
+    List<User> findByRegionAndRoleAndNameContainingIgnoreCase(Region region, User.Role role, String name);
 }

--- a/src/main/java/com/example/moyeorak/repository/UserRepository.java
+++ b/src/main/java/com/example/moyeorak/repository/UserRepository.java
@@ -1,11 +1,14 @@
 package com.example.moyeorak.repository;
 
+import com.example.moyeorak.entity.Region;
 import com.example.moyeorak.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByPhone(String phone);
+    List<User> findByRegion(Region region);
 }

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -5,6 +5,7 @@ import com.example.moyeorak.entity.Region;
 import com.example.moyeorak.entity.User;
 import com.example.moyeorak.jwt.JwtProvider;
 import com.example.moyeorak.repository.UserRepository;
+import com.example.moyeorak.repository.RegionRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,9 +19,10 @@ public class AdminUserService {
 
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
+    private final RegionRepository regionRepository;
 
     // 토큰 기반으로 관리자 식별 + 담당 지역 유저 조회
-    public List<AdminUserListResponseDto> getUsersByRegionFromToken(HttpServletRequest request) {
+    public List<AdminUserListResponseDto> getUsersByRegion(HttpServletRequest request, Long regionId) {
         // 1. 토큰에서 관리자 이메일 꺼내기
         String token = jwtProvider.resolveToken(request);
         String email = jwtProvider.getEmail(token);
@@ -33,16 +35,22 @@ public class AdminUserService {
             throw new IllegalAccessError("관리자 권한이 없습니다.");
         }
 
-        // 3. 관리자 담당 지역 확인
-        Region region = admin.getRegion();
-        if (region == null) {
-            throw new IllegalStateException("관리자에게 지역 정보가 설정되어 있지 않습니다.");
+        // 3. 조회할 지역 결정
+        Region targetRegion;
+        if (regionId == null) {
+            targetRegion = admin.getRegion();
+            if (targetRegion == null) {
+                throw new IllegalStateException("관리자에게 지역 정보가 설정되어 있지 않습니다.");
+            }
+        } else {
+            targetRegion = regionRepository.findById(regionId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 지역이 존재하지 않습니다."));
         }
 
-        // 4. 해당 지역의 일반 유저만 조회 (관리자는 제외)
-        List<User> users = userRepository.findByRegionAndRole(region, User.Role.USER);
+        // 4. 일반 유저만 조회 (관리자 제외)
+        List<User> users = userRepository.findByRegionAndRole(targetRegion, User.Role.USER);
 
-        // 5. DTO로 변환
+        // 5. DTO 변환
         return users.stream()
                 .map(user -> new AdminUserListResponseDto(
                         user.getId(),

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -3,6 +3,7 @@ package com.example.moyeorak.service.admin;
 import com.example.moyeorak.dto.admin.AdminUserCreateRequestDto;
 import com.example.moyeorak.dto.admin.AdminUserDetailResponseDto;
 import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
+import com.example.moyeorak.dto.admin.AdminUserUpdateRequestDto;
 import com.example.moyeorak.entity.Region;
 import com.example.moyeorak.entity.User;
 import com.example.moyeorak.jwt.JwtProvider;
@@ -152,4 +153,31 @@ public class AdminUserService {
                 .regionName(user.getRegion().getName())
                 .build();
     }
+
+
+    // 회원정보 수정
+    @Transactional
+    public void updateUserInfo(Long userId, AdminUserUpdateRequestDto dto) {
+        // 1. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+
+        // 2. email 수정
+        if (dto.getEmail() != null) {
+            user.setEmail(dto.getEmail());
+        }
+
+        // 3. phone 수정
+        if (dto.getPhone() != null) {
+            user.setPhone(dto.getPhone());
+        }
+
+        // 4. region 수정
+        if (dto.getRegionId() != null) {
+            Region region = regionRepository.findById(dto.getRegionId())
+                    .orElseThrow(() -> new IllegalArgumentException("해당 지역이 존재하지 않습니다."));
+            user.setRegion(region);
+        }
+    }
+
 }

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -3,7 +3,9 @@ package com.example.moyeorak.service.admin;
 import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
 import com.example.moyeorak.entity.Region;
 import com.example.moyeorak.entity.User;
+import com.example.moyeorak.jwt.JwtProvider;
 import com.example.moyeorak.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,22 +17,32 @@ import java.util.List;
 public class AdminUserService {
 
     private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
 
-    public List<AdminUserListResponseDto> getUsersByRegion(Long adminId) {
-        // 1. 관리자 유저 정보 가져오기
-        User admin = userRepository.findById(adminId)
+    // ✅ 토큰 기반으로 관리자 식별 + 담당 지역 유저 조회
+    public List<AdminUserListResponseDto> getUsersByRegionFromToken(HttpServletRequest request) {
+        // 1. 토큰에서 관리자 이메일 꺼내기
+        String token = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(token);
+
+        // 2. 관리자 유저 조회
+        User admin = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("관리자 정보가 없습니다."));
 
-        // 2. 관리자 지역 정보 가져오기
+        if (admin.getRole() != User.Role.ADMIN) {
+            throw new IllegalAccessError("관리자 권한이 없습니다.");
+        }
+
+        // 3. 관리자 담당 지역 확인
         Region region = admin.getRegion();
         if (region == null) {
             throw new IllegalStateException("관리자에게 지역 정보가 설정되어 있지 않습니다.");
         }
 
-        // 3. 해당 지역 유저 전체 조회
+        // 4. 해당 지역 유저 조회
         List<User> users = userRepository.findByRegion(region);
 
-        // 4. DTO로 변환해서 반환
+        // 5. DTO로 변환
         return users.stream()
                 .map(user -> new AdminUserListResponseDto(
                         user.getId(),

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -19,7 +19,7 @@ public class AdminUserService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
 
-    // ✅ 토큰 기반으로 관리자 식별 + 담당 지역 유저 조회
+    // 토큰 기반으로 관리자 식별 + 담당 지역 유저 조회
     public List<AdminUserListResponseDto> getUsersByRegionFromToken(HttpServletRequest request) {
         // 1. 토큰에서 관리자 이메일 꺼내기
         String token = jwtProvider.resolveToken(request);
@@ -39,8 +39,8 @@ public class AdminUserService {
             throw new IllegalStateException("관리자에게 지역 정보가 설정되어 있지 않습니다.");
         }
 
-        // 4. 해당 지역 유저 조회
-        List<User> users = userRepository.findByRegion(region);
+        // 4. 해당 지역의 일반 유저만 조회 (관리자는 제외)
+        List<User> users = userRepository.findByRegionAndRole(region, User.Role.USER);
 
         // 5. DTO로 변환
         return users.stream()

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -1,6 +1,7 @@
 package com.example.moyeorak.service.admin;
 
 import com.example.moyeorak.dto.admin.AdminUserCreateRequestDto;
+import com.example.moyeorak.dto.admin.AdminUserDetailResponseDto;
 import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
 import com.example.moyeorak.entity.Region;
 import com.example.moyeorak.entity.User;
@@ -116,5 +117,39 @@ public class AdminUserService {
             case "여" -> User.Gender.FEMALE;
             default -> throw new IllegalArgumentException("성별은 '남' 또는 '여'여야 합니다.");
         };
+    }
+
+    // 회원 상세정보 응답
+    public AdminUserDetailResponseDto getUserDetail(Long userId, HttpServletRequest request) {
+        // 1. 관리자 인증
+        String token = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(token);
+
+        User admin = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("관리자 정보가 없습니다."));
+        if (admin.getRole() != User.Role.ADMIN) {
+            throw new IllegalAccessError("관리자 권한이 없습니다.");
+        }
+
+        // 2. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+
+        // 3. 유저가 관리자 담당 지역 유저인지 검증
+        if (!user.getRegion().getId().equals(admin.getRegion().getId())) {
+            throw new IllegalAccessError("관리자 담당 지역 유저가 아닙니다.");
+        }
+
+        // 4. 응답 DTO 구성
+        return AdminUserDetailResponseDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .gender(user.getGender() == User.Gender.MALE ? "남" : "여")
+                .createdAt(user.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .email(user.getEmail())
+                .phone(user.getPhone())
+                .regionId(user.getRegion().getId())
+                .regionName(user.getRegion().getName())
+                .build();
     }
 }

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -1,5 +1,6 @@
 package com.example.moyeorak.service.admin;
 
+import com.example.moyeorak.dto.admin.AdminUserCreateRequestDto;
 import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
 import com.example.moyeorak.entity.Region;
 import com.example.moyeorak.entity.User;
@@ -7,9 +8,12 @@ import com.example.moyeorak.jwt.JwtProvider;
 import com.example.moyeorak.repository.UserRepository;
 import com.example.moyeorak.repository.RegionRepository;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -20,6 +24,7 @@ public class AdminUserService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
     private final RegionRepository regionRepository;
+    private final PasswordEncoder passwordEncoder;
 
     // 토큰 기반으로 관리자 식별 + 담당 지역 유저 조회 (키워드 필터링 포함)
     public List<AdminUserListResponseDto> getUsersByRegionAndKeyword(HttpServletRequest request, Long regionId, String keyword) {
@@ -66,5 +71,50 @@ public class AdminUserService {
                         user.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
                 ))
                 .toList();
+    }
+
+
+    // 관리자 지역 기반으로 해당 지역 유저 생성
+    @Transactional
+    public void createUser(AdminUserCreateRequestDto dto, HttpServletRequest request) {
+        // 1. 관리자 인증
+        String token = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(token);
+
+        User admin = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("관리자 정보가 없습니다."));
+
+        if (admin.getRole() != User.Role.ADMIN) {
+            throw new IllegalAccessError("관리자 권한이 없습니다.");
+        }
+
+        // 2. 관리자 지역 가져오기
+        Region region = admin.getRegion();
+        if (region == null) {
+            throw new IllegalStateException("관리자 지역 정보가 없습니다.");
+        }
+
+        // 3. 유저 생성
+        User newUser = User.builder()
+                .email(dto.getEmail().trim().toLowerCase())
+                .password(passwordEncoder.encode(dto.getPassword()))
+                .name(dto.getName())
+                .gender(parseGender(dto.getGender()))
+                .phone(dto.getPhone())
+                .birth(LocalDate.parse(dto.getBirth())) // "2025-07-20" 형식
+                .role(User.Role.USER)
+                .region(region)
+                .build();
+
+        // 4. 저장
+        userRepository.save(newUser);
+    }
+
+    private User.Gender parseGender(String gender) {
+        return switch (gender.trim()) {
+            case "남" -> User.Gender.MALE;
+            case "여" -> User.Gender.FEMALE;
+            default -> throw new IllegalArgumentException("성별은 '남' 또는 '여'여야 합니다.");
+        };
     }
 }

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -36,7 +36,7 @@ public class AdminUserService {
                 .orElseThrow(() -> new IllegalArgumentException("관리자 정보가 없습니다."));
 
         if (admin.getRole() != User.Role.ADMIN) {
-            throw new IllegalAccessError("관리자 권한이 없습니다.");
+            throw new IllegalArgumentException("관리자 권한이 없습니다.");
         }
 
         // 3. 조회할 지역 결정
@@ -126,7 +126,7 @@ public class AdminUserService {
         User admin = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("관리자 정보가 없습니다."));
         if (admin.getRole() != User.Role.ADMIN) {
-            throw new IllegalAccessError("관리자 권한이 없습니다.");
+            throw new IllegalArgumentException("관리자 권한이 없습니다.");
         }
 
         // 2. 유저 조회
@@ -135,7 +135,7 @@ public class AdminUserService {
 
         // 3. 유저가 관리자 담당 지역 유저인지 검증
         if (!user.getRegion().getId().equals(admin.getRegion().getId())) {
-            throw new IllegalAccessError("관리자 담당 지역 유저가 아닙니다.");
+            throw new IllegalArgumentException("관리자 담당 지역 유저가 아닙니다.");
         }
 
         // 4. 응답 DTO 구성

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 @Service
@@ -94,13 +95,19 @@ public class AdminUserService {
         }
 
         // 3. 유저 생성
+
+        // null 체크 먼저
+        if (dto.getEmail() == null) {
+            throw new IllegalArgumentException("Email cannot be null.");
+        }
+
         User newUser = User.builder()
                 .email(dto.getEmail().trim().toLowerCase())
                 .password(passwordEncoder.encode(dto.getPassword()))
                 .name(dto.getName())
                 .gender(parseGender(dto.getGender()))
                 .phone(dto.getPhone())
-                .birth(LocalDate.parse(dto.getBirth())) // "2025-07-20" 형식
+                .birth(parseBirthDate(dto.getBirth()))
                 .role(User.Role.USER)
                 .region(region)
                 .build();
@@ -115,6 +122,14 @@ public class AdminUserService {
             case "여" -> User.Gender.FEMALE;
             default -> throw new IllegalArgumentException("성별은 '남' 또는 '여'여야 합니다.");
         };
+    }
+
+    private LocalDate parseBirthDate(String birth) {
+        try {
+            return LocalDate.parse(birth);  // yyyy-MM-dd 형식 기대
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("생년월일 형식이 잘못되었습니다: " + birth);
+        }
     }
 
     // 회원 상세정보 응답

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -21,8 +21,8 @@ public class AdminUserService {
     private final JwtProvider jwtProvider;
     private final RegionRepository regionRepository;
 
-    // 토큰 기반으로 관리자 식별 + 담당 지역 유저 조회
-    public List<AdminUserListResponseDto> getUsersByRegion(HttpServletRequest request, Long regionId) {
+    // 토큰 기반으로 관리자 식별 + 담당 지역 유저 조회 (키워드 필터링 포함)
+    public List<AdminUserListResponseDto> getUsersByRegionAndKeyword(HttpServletRequest request, Long regionId, String keyword) {
         // 1. 토큰에서 관리자 이메일 꺼내기
         String token = jwtProvider.resolveToken(request);
         String email = jwtProvider.getEmail(token);
@@ -47,8 +47,13 @@ public class AdminUserService {
                     .orElseThrow(() -> new IllegalArgumentException("해당 지역이 존재하지 않습니다."));
         }
 
-        // 4. 일반 유저만 조회 (관리자 제외)
-        List<User> users = userRepository.findByRegionAndRole(targetRegion, User.Role.USER);
+        // 4. 일반 유저만 조회 (관리자 제외) + 키워드 필터링
+        List<User> users;
+        if (keyword == null || keyword.trim().isEmpty()) {
+            users = userRepository.findByRegionAndRole(targetRegion, User.Role.USER);
+        } else {
+            users = userRepository.findByRegionAndRoleAndNameContainingIgnoreCase(targetRegion, User.Role.USER, keyword.trim());
+        }
 
         // 5. DTO 변환
         return users.stream()

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -1,9 +1,6 @@
 package com.example.moyeorak.service.admin;
 
-import com.example.moyeorak.dto.admin.AdminUserCreateRequestDto;
-import com.example.moyeorak.dto.admin.AdminUserDetailResponseDto;
-import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
-import com.example.moyeorak.dto.admin.AdminUserUpdateRequestDto;
+import com.example.moyeorak.dto.admin.*;
 import com.example.moyeorak.entity.Region;
 import com.example.moyeorak.entity.User;
 import com.example.moyeorak.jwt.JwtProvider;
@@ -178,6 +175,22 @@ public class AdminUserService {
                     .orElseThrow(() -> new IllegalArgumentException("해당 지역이 존재하지 않습니다."));
             user.setRegion(region);
         }
+    }
+
+    // 비밀번호 변경
+    @Transactional
+    public void updateUserPassword(Long userId, AdminPasswordUpdateRequestDto dto) {
+        // 1. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+
+        // 2. 새 비밀번호 확인
+        if (!dto.getNewPassword().equals(dto.getConfirmPassword())) {
+            throw new IllegalArgumentException("새 비밀번호와 확인 비밀번호가 일치하지 않습니다.");
+        }
+
+        // 3. 비밀번호 업데이트
+        user.setPassword(passwordEncoder.encode(dto.getNewPassword()));
     }
 
 }

--- a/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminUserService.java
@@ -1,0 +1,45 @@
+package com.example.moyeorak.service.admin;
+
+import com.example.moyeorak.dto.admin.AdminUserListResponseDto;
+import com.example.moyeorak.entity.Region;
+import com.example.moyeorak.entity.User;
+import com.example.moyeorak.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+
+    public List<AdminUserListResponseDto> getUsersByRegion(Long adminId) {
+        // 1. 관리자 유저 정보 가져오기
+        User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> new IllegalArgumentException("관리자 정보가 없습니다."));
+
+        // 2. 관리자 지역 정보 가져오기
+        Region region = admin.getRegion();
+        if (region == null) {
+            throw new IllegalStateException("관리자에게 지역 정보가 설정되어 있지 않습니다.");
+        }
+
+        // 3. 해당 지역 유저 전체 조회
+        List<User> users = userRepository.findByRegion(region);
+
+        // 4. DTO로 변환해서 반환
+        return users.stream()
+                .map(user -> new AdminUserListResponseDto(
+                        user.getId(),
+                        user.getName(),
+                        user.getGender().name(),
+                        user.getEmail(),
+                        user.getRegion().getName(),
+                        user.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
+                ))
+                .toList();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,35 +1,16 @@
+spring.cloud.aws.sqs.enabled=false
+
+
 spring.application.name=moyeorak
+spring.profiles.active=local
 
 # ===============================
 # = DATABASE CONNECTION SETTINGS
 # ===============================
-#spring.datasource.url=jdbc:mysql://localhost:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.url=jdbc:mysql://goorm-mysql.c92y0sa8e7t2.ap-northeast-2.rds.amazonaws.com:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=choi
-spring.datasource.password=1q2w3e4r!!
+spring.datasource.url=jdbc:mysql://localhost:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
-# ===============================
-# = REDIS SETTINGS
-# ===============================
-#spring.redis.host=goorm-redis.m98tqf.ng.0001.apn2.cache.amazonaws.com
-#spring.redis.port=6379
-#spring.cache.type=redis
-
-# ===============================
-# = S3 SETTINGS    =
-# ===============================
-cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
-cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
-cloud.aws.s3.bucket=s3-storage-image
-cloud.aws.region.static=ap-northeast-2
-cloud.aws.stack.auto=false
-
-# ===============================
-# = SQS SETTINGS    =
-# ===============================
-sqs.queue.url=https://sqs.ap-northeast-2.amazonaws.com/004407157704/goorm-rental-sqs
-spring.cloud.aws.sqs.enabled=false
 
 # ===============================
 # = JPA / HIBERNATE SETTINGS

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,36 +1,29 @@
-spring.cloud.aws.sqs.enabled=false
-
-
-spring.application.name=moyeorak
-spring.profiles.active=local
-
 # ===============================
 # = DATABASE CONNECTION SETTINGS
 # ===============================
-spring.datasource.url=jdbc:mysql://localhost:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=root
-spring.datasource.password=
+#spring.datasource.url=jdbc:mysql://localhost:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://goorm-mysql.c92y0sa8e7t2.ap-northeast-2.rds.amazonaws.com:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.username=choi
+spring.datasource.password=1q2w3e4r!!
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # ===============================
-# = JPA / HIBERNATE SETTINGS
+# = REDIS SETTINGS
 # ===============================
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+#spring.redis.host=goorm-redis.m98tqf.ng.0001.apn2.cache.amazonaws.com
+#spring.redis.port=6379
+#spring.cache.type=redis
 
 # ===============================
-# = SERVER SETTINGS
+# = S3 SETTINGS    =
 # ===============================
-server.port=8080
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
+cloud.aws.s3.bucket=s3-storage-image
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto=false
 
 # ===============================
-# = SECURITY SETTINGS
+# = SQS SETTINGS    =
 # ===============================
-jwt.secret=Y29tZXhhbXBsZWtleTEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MA==
-
-# ===============================
-# = MONITORING
-# ===============================
-management.endpoints.web.exposure.include=health,info
+sqs.queue.url=https://sqs.ap-northeast-2.amazonaws.com/004407157704/goorm-rental-sqs

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+spring.application.name=moyeorak
+
 # ===============================
 # = DATABASE CONNECTION SETTINGS
 # ===============================
@@ -27,3 +29,27 @@ cloud.aws.stack.auto=false
 # = SQS SETTINGS    =
 # ===============================
 sqs.queue.url=https://sqs.ap-northeast-2.amazonaws.com/004407157704/goorm-rental-sqs
+spring.cloud.aws.sqs.enabled=false
+
+# ===============================
+# = JPA / HIBERNATE SETTINGS
+# ===============================
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+# ===============================
+# = SERVER SETTINGS
+# ===============================
+server.port=8080
+
+# ===============================
+# = SECURITY SETTINGS
+# ===============================
+jwt.secret=Y29tZXhhbXBsZWtleTEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MA==
+
+# ===============================
+# = MONITORING
+# ===============================
+management.endpoints.web.exposure.include=health,info


### PR DESCRIPTION
## 구현 기능
- 관리자 전용 유저 목록 조회 (관리자 지역 기반 필터링 포함)
- 지역 선택/이름 검색 기능
- 유저 상세 조회
- 유저 정보 수정
- 유저 생성 (관리자 권한으로 신규 유저 등록 가능)

## 테스트
- Postman으로 각 API 정상 동작 확인
- 필수 필드 누락 등 실패 케이스도 테스트 완료

## 기타 참고사항
- 기존 코드 수정 X, 추가만 함
- `AdminUserService`로 관리자 전용 서비스 분리
- DTO는 `dto/admin/`에 따로 정리
- `application.properties`는 기존 상태로 복구하여 푸시함

## 관련 이슈
- refs #1 
- refs #2 
- refs #3 