### PR TITLE
fix: 수강 취소 후 재신청 시 중복 에러 수정 (#14)

### DIFF
--- a/src/main/java/com/example/moyeorak/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/moyeorak/repository/EnrollmentRepository.java
@@ -12,6 +12,9 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     boolean existsByUserIdAndProgramId(Long userId, Long programId);
     boolean existsByUserIdAndProgramIdAndStatusNot(Long userId, Long programId, Enrollment.Status status);
+
+    Optional<Enrollment> findByUserIdAndProgramId(Long userId, Long programId);
+
     List<Enrollment> findByUserId(Long userId);
     Optional<Enrollment> findByIdAndUserId(Long id, Long userId);
 

--- a/src/main/java/com/example/moyeorak/service/EnrollmentService.java
+++ b/src/main/java/com/example/moyeorak/service/EnrollmentService.java
@@ -38,19 +38,26 @@ public class EnrollmentService {
         Program program = programRepository.findById(request.getProgramId())
                 .orElseThrow(() -> new IllegalArgumentException("프로그램 정보가 없습니다."));
 
-        // ✅ 중복 수강 신청 체크 및 재신청 허용 로직
         Optional<Enrollment> existing = enrollmentRepository.findByUserIdAndProgramId(user.getId(), program.getId());
+
+        boolean inRegion = isInRegion(user, program);
+        int paidAmount = inRegion ? program.getInPrice() : program.getOutPrice();
 
         if (existing.isPresent()) {
             Enrollment prev = existing.get();
             if (prev.getStatus() != Enrollment.Status.CANCELLED) {
                 throw new IllegalArgumentException("이미 신청한 프로그램입니다.");
             }
-            enrollmentRepository.delete(prev); // ✅ 취소된 신청이면 삭제 후 진행
-        }
 
-        boolean inRegion = isInRegion(user, program);
-        int paidAmount = inRegion ? program.getInPrice() : program.getOutPrice();
+            // ✅ 삭제 대신 재활용 방식
+            prev.setStatus(Enrollment.Status.ENROLLED);
+            prev.setPaidAmount(paidAmount);
+            prev.setClassStartTime(program.getClassStartTime());
+            prev.setClassEndTime(program.getClassEndTime());
+            prev.setRegion(program.getRegion());
+            prev.setCancelReason(null); // 취소 사유 초기화
+            return toResponse(enrollmentRepository.save(prev), user);
+        }
 
         Enrollment enrollment = Enrollment.builder()
                 .user(user)

--- a/src/main/java/com/example/moyeorak/service/EnrollmentService.java
+++ b/src/main/java/com/example/moyeorak/service/EnrollmentService.java
@@ -9,17 +9,10 @@ import com.example.moyeorak.entity.User;
 import com.example.moyeorak.repository.EnrollmentRepository;
 import com.example.moyeorak.repository.ProgramRepository;
 import com.example.moyeorak.repository.UserRepository;
-import com.example.moyeorak.security.CustomUserDetails;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -45,10 +38,15 @@ public class EnrollmentService {
         Program program = programRepository.findById(request.getProgramId())
                 .orElseThrow(() -> new IllegalArgumentException("프로그램 정보가 없습니다."));
 
-        // ✅ 중복 수강 신청 체크 (CANCELLED 제외)
-        if (enrollmentRepository.existsByUserIdAndProgramIdAndStatusNot(
-                user.getId(), program.getId(), Enrollment.Status.CANCELLED)) {
-            throw new IllegalArgumentException("이미 신청한 프로그램입니다.");
+        // ✅ 중복 수강 신청 체크 및 재신청 허용 로직
+        Optional<Enrollment> existing = enrollmentRepository.findByUserIdAndProgramId(user.getId(), program.getId());
+
+        if (existing.isPresent()) {
+            Enrollment prev = existing.get();
+            if (prev.getStatus() != Enrollment.Status.CANCELLED) {
+                throw new IllegalArgumentException("이미 신청한 프로그램입니다.");
+            }
+            enrollmentRepository.delete(prev); // ✅ 취소된 신청이면 삭제 후 진행
         }
 
         boolean inRegion = isInRegion(user, program);
@@ -156,5 +154,4 @@ public class EnrollmentService {
                 .cancelEndDate(program.getCancelEndDate())
                 .build();
     }
-
 }


### PR DESCRIPTION
## 문제
수강 신청 후 취소하고 같은 프로그램을 다시 신청할 경우, DB의 unique 제약조건으로 인해 중복 신청 에러가 발생했습니다.

## 해결
- 기존에 신청된 Enrollment가 존재할 경우, 상태가 CANCELLED이면 삭제 후 새로 신청 가능하도록 수정했습니다.
- EnrollmentService 내부에 로직을 반영했습니다.

## 관련 이슈
Closes #14