### PR TITLE
Fix/enrollment duplicate reapply 14

### DIFF
--- a/src/main/java/com/example/moyeorak/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/moyeorak/repository/EnrollmentRepository.java
@@ -12,6 +12,9 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     boolean existsByUserIdAndProgramId(Long userId, Long programId);
     boolean existsByUserIdAndProgramIdAndStatusNot(Long userId, Long programId, Enrollment.Status status);
+
+    Optional<Enrollment> findByUserIdAndProgramId(Long userId, Long programId);
+
     List<Enrollment> findByUserId(Long userId);
     Optional<Enrollment> findByIdAndUserId(Long id, Long userId);
 

--- a/src/main/java/com/example/moyeorak/service/EnrollmentService.java
+++ b/src/main/java/com/example/moyeorak/service/EnrollmentService.java
@@ -2,7 +2,6 @@ package com.example.moyeorak.service;
 
 import com.example.moyeorak.dto.EnrollmentRequest;
 import com.example.moyeorak.dto.EnrollmentResponse;
-import com.example.moyeorak.dto.MessageResponse;
 import com.example.moyeorak.entity.Enrollment;
 import com.example.moyeorak.entity.Program;
 import com.example.moyeorak.entity.User;
@@ -34,32 +33,33 @@ public class EnrollmentService {
 
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자 정보가 없습니다."));
-
         Program program = programRepository.findById(request.getProgramId())
                 .orElseThrow(() -> new IllegalArgumentException("프로그램 정보가 없습니다."));
-
-        Optional<Enrollment> existing = enrollmentRepository.findByUserIdAndProgramId(user.getId(), program.getId());
 
         boolean inRegion = isInRegion(user, program);
         int paidAmount = inRegion ? program.getInPrice() : program.getOutPrice();
 
-        if (existing.isPresent()) {
-            Enrollment prev = existing.get();
-            if (prev.getStatus() != Enrollment.Status.CANCELLED) {
+        Optional<Enrollment> existingOpt = enrollmentRepository.findByUserIdAndProgramId(user.getId(), program.getId());
+
+        if (existingOpt.isPresent()) {
+            Enrollment existing = existingOpt.get();
+            if (existing.getStatus() != Enrollment.Status.CANCELLED) {
                 throw new IllegalArgumentException("이미 신청한 프로그램입니다.");
             }
 
-            // ✅ 삭제 대신 재활용 방식
-            prev.setStatus(Enrollment.Status.ENROLLED);
-            prev.setPaidAmount(paidAmount);
-            prev.setClassStartTime(program.getClassStartTime());
-            prev.setClassEndTime(program.getClassEndTime());
-            prev.setRegion(program.getRegion());
-            prev.setCancelReason(null); // 취소 사유 초기화
-            return toResponse(enrollmentRepository.save(prev), user);
+            // ✅ 삭제 대신 재사용 방식 (unique 제약 조건 회피 + 기록 유지)
+            existing.setStatus(Enrollment.Status.ENROLLED);
+            existing.setPaidAmount(paidAmount);
+            existing.setClassStartTime(program.getClassStartTime());
+            existing.setClassEndTime(program.getClassEndTime());
+            existing.setRegion(program.getRegion());
+            existing.setCancelReason("");  // 취소 사유 초기화 (nullable 방지)
+
+            Enrollment saved = enrollmentRepository.save(existing);
+            return toResponse(saved, user);
         }
 
-        Enrollment enrollment = Enrollment.builder()
+        Enrollment newEnrollment = Enrollment.builder()
                 .user(user)
                 .program(program)
                 .region(program.getRegion())
@@ -69,7 +69,7 @@ public class EnrollmentService {
                 .classEndTime(program.getClassEndTime())
                 .build();
 
-        Enrollment saved = enrollmentRepository.save(enrollment);
+        Enrollment saved = enrollmentRepository.save(newEnrollment);
         return toResponse(saved, user);
     }
 
@@ -118,7 +118,6 @@ public class EnrollmentService {
     @Transactional
     public void cancelEnrollmentByAdmin(Long id, String reason) {
         log.info("[ADMIN CANCEL] 관리자 수강 취소 요청 - id: {}, reason: {}", id, reason);
-
         Enrollment enrollment = getEnrollment(id);
         enrollment.setStatus(Enrollment.Status.CANCELLED);
         enrollment.setCancelReason(reason);

--- a/src/main/java/com/example/moyeorak/service/EnrollmentService.java
+++ b/src/main/java/com/example/moyeorak/service/EnrollmentService.java
@@ -38,19 +38,26 @@ public class EnrollmentService {
         Program program = programRepository.findById(request.getProgramId())
                 .orElseThrow(() -> new IllegalArgumentException("프로그램 정보가 없습니다."));
 
-        // ✅ 중복 수강 신청 체크 및 재신청 허용 로직
         Optional<Enrollment> existing = enrollmentRepository.findByUserIdAndProgramId(user.getId(), program.getId());
+
+        boolean inRegion = isInRegion(user, program);
+        int paidAmount = inRegion ? program.getInPrice() : program.getOutPrice();
 
         if (existing.isPresent()) {
             Enrollment prev = existing.get();
             if (prev.getStatus() != Enrollment.Status.CANCELLED) {
                 throw new IllegalArgumentException("이미 신청한 프로그램입니다.");
             }
-            enrollmentRepository.delete(prev); // ✅ 취소된 신청이면 삭제 후 진행
-        }
 
-        boolean inRegion = isInRegion(user, program);
-        int paidAmount = inRegion ? program.getInPrice() : program.getOutPrice();
+            // ✅ 삭제 대신 재활용 방식
+            prev.setStatus(Enrollment.Status.ENROLLED);
+            prev.setPaidAmount(paidAmount);
+            prev.setClassStartTime(program.getClassStartTime());
+            prev.setClassEndTime(program.getClassEndTime());
+            prev.setRegion(program.getRegion());
+            prev.setCancelReason(null); // 취소 사유 초기화
+            return toResponse(enrollmentRepository.save(prev), user);
+        }
 
         Enrollment enrollment = Enrollment.builder()
                 .user(user)

--- a/src/main/java/com/example/moyeorak/service/EnrollmentService.java
+++ b/src/main/java/com/example/moyeorak/service/EnrollmentService.java
@@ -9,17 +9,10 @@ import com.example.moyeorak.entity.User;
 import com.example.moyeorak.repository.EnrollmentRepository;
 import com.example.moyeorak.repository.ProgramRepository;
 import com.example.moyeorak.repository.UserRepository;
-import com.example.moyeorak.security.CustomUserDetails;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -45,10 +38,15 @@ public class EnrollmentService {
         Program program = programRepository.findById(request.getProgramId())
                 .orElseThrow(() -> new IllegalArgumentException("프로그램 정보가 없습니다."));
 
-        // ✅ 중복 수강 신청 체크 (CANCELLED 제외)
-        if (enrollmentRepository.existsByUserIdAndProgramIdAndStatusNot(
-                user.getId(), program.getId(), Enrollment.Status.CANCELLED)) {
-            throw new IllegalArgumentException("이미 신청한 프로그램입니다.");
+        // ✅ 중복 수강 신청 체크 및 재신청 허용 로직
+        Optional<Enrollment> existing = enrollmentRepository.findByUserIdAndProgramId(user.getId(), program.getId());
+
+        if (existing.isPresent()) {
+            Enrollment prev = existing.get();
+            if (prev.getStatus() != Enrollment.Status.CANCELLED) {
+                throw new IllegalArgumentException("이미 신청한 프로그램입니다.");
+            }
+            enrollmentRepository.delete(prev); // ✅ 취소된 신청이면 삭제 후 진행
         }
 
         boolean inRegion = isInRegion(user, program);
@@ -156,5 +154,4 @@ public class EnrollmentService {
                 .cancelEndDate(program.getCancelEndDate())
                 .build();
     }
-
 }


### PR DESCRIPTION
## 문제
사용자가 프로그램 수강 신청 후 **취소하고 다시 신청**할 경우,  
`(user_id, program_id)`에 유니크 제약조건이 걸려 있어서 **중복 신청 에러(Duplicate Entry)**가 발생했습니다.

## 해결
- 기존에 `ENROLLMENT`가 존재하고 `Status = CANCELLED`인 경우:
  - 해당 엔티티를 삭제한 뒤, 새롭게 신청을 저장하도록 처리했습니다.
- 중복 신청 방지 로직을 `EnrollmentService.enrollByEmail()` 내부에 반영했습니다.

## 관련 이슈
Closes #14