### PR TITLE
fix: add localhost:5173 to allowedOrigins for CORS (Fixes #27)

### DIFF
--- a/src/main/java/com/example/moyeorak/config/SecurityConfig.java
+++ b/src/main/java/com/example/moyeorak/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
         config.setAllowedOrigins(List.of(
                 "http://localhost:3000",
                 "http://localhost:8080",
+                "http://localhost:5173",
                 "http://goorm-alb-1610121085.ap-northeast-2.elb.amazonaws.com",
                 "https://www.moyeorak.cloud",
                 "https://moyeorak.cloud",


### PR DESCRIPTION
### 🔧 변경 내용
- CORS 설정에서 누락되어 있던 `http://localhost:5173`를 `allowedOrigins`에 추가하였습니다.
- 프론트엔드(Vite 개발 서버)에서 로그인 요청 시 발생하던 CORS 오류(`No 'Access-Control-Allow-Origin' header`) 해결을 위한 수정입니다.

### 📌 관련 이슈
Fixes #27

### ✅ 테스트 내역
- [x] Postman에서 로그인 API 정상 동작 확인
- [x] 브라우저(5173포트)에서 로그인 요청 시 CORS 에러 해결 확인