### PR TITLE
chore: align jackson to 2.17.+ and force commons-lang3 3.18.0 (Snyk fix)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation platform('com.fasterxml.jackson:jackson-bom:2.17.+')
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -43,6 +44,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.2")
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
+    constraints {
+        implementation('org.apache.commons:commons-lang3:3.18.0') {
+            because 'Snyk 보고서 대응: springdoc가 끌고오는 3.17.0을 덮어씌움'
+        }
+    }
+
     //implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     //implementation 'io.awspring.cloud:spring-cloud-aws-messaging:3.1.0'
 


### PR DESCRIPTION
## 📌 변경 내용
- commons-lang3 버전을 3.18.0으로 업그레이드
  - Uncontrolled Recursion 취약점 (CWE-674, CVE-2025-48924) 대응
  - springdoc-openapi-starter-webmvc-ui 2.7.0이 끌고 오는 3.17.0을 오버라이드
- Jackson 계열 라이브러리를 2.17.+ 버전으로 정렬
  - DoS (CWE-400) 및 Stack-based Buffer Overflow (CWE-121) 취약점 대응

## 🔍 참고
- 취약점 보고: Snyk Security Report
- 관련 CVE:
  - CVE-2025-48924 (commons-lang3)
  - CVE-2025-52999 (jackson-core)
  - CVE-2025-52998 (jackson-core)
- 영향 받는 경로:
  - `springdoc-openapi-starter-webmvc-ui:2.7.0`
  - `io.jsonwebtoken:jjwt-jackson:0.11.5`