### PR TITLE
fix: block blob:/data: URLs and normalize facility image URL handling

### DIFF
--- a/src/main/java/com/example/moyeorak/service/FacilityService.java
+++ b/src/main/java/com/example/moyeorak/service/FacilityService.java
@@ -29,39 +29,76 @@ public class FacilityService {
     @Value("${cloudfront.base-url}")
     private String cloudFrontBaseUrl;
 
-    // 과거/입력으로 들어올 수 있는 S3 URL 식별용
-    private static final String S3_HOST_PREFIX = "https://s3-goorm-frontend.s3.ap-northeast-2.amazonaws.com/";
-
     private String formatUsageTime(Facility facility) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
         return facility.getUsageStartTime().format(formatter) + " ~ " + facility.getUsageEndTime().format(formatter);
     }
 
     /**
-     * 들어온 값(파일명 혹은 절대 URL)을 '파일명'만 남기도록 정규화
-     * - S3 전체 URL, CloudFront 전체 URL 모두 대응
+     * 들어온 값(파일명/오브젝트 키 혹은 절대 URL)을 '파일명/오브젝트 키'만 남기도록 정규화
+     * - blob:/data: URL은 거부
+     * - http(s) URL은 마지막 '/' 뒤만 추출(쿼리/프래그먼트 제거)
+     * - ':' 문자가 남아 있으면 거부(스킴 혼입 방지)
+     * - 'img/2025/08/foo.jpg' 같은 오브젝트 키는 허용
      */
     private String normalizeToFileName(String raw) {
         if (raw == null || raw.isBlank()) return null;
         String val = raw.trim();
 
-        // 절대 URL이면 마지막 "/" 뒤만 추출
-        if (val.startsWith("http://") || val.startsWith("https://")) {
-            return val.substring(val.lastIndexOf('/') + 1);
+        // 프런트 전용/인라인 데이터는 즉시 거부
+        if (val.startsWith("blob:")) {
+            throw new IllegalArgumentException("blob: URL은 허용되지 않습니다. S3 업로드 후 파일명(또는 오브젝트 키)만 전달하세요.");
         }
-        // 이미 파일명이면 그대로 반환
+        if (val.startsWith("data:")) {
+            throw new IllegalArgumentException("data: URL은 허용되지 않습니다. S3 업로드 후 파일명(또는 오브젝트 키)만 전달하세요.");
+        }
+
+        // 절대 URL 처리
+        if (val.startsWith("http://") || val.startsWith("https://")) {
+            int qm = val.indexOf('?');
+            int hash = val.indexOf('#');
+            int cut = val.length();
+            if (qm >= 0) cut = Math.min(cut, qm);
+            if (hash >= 0) cut = Math.min(cut, hash);
+
+            String withoutQuery = val.substring(0, cut);
+            String fileName = withoutQuery.substring(withoutQuery.lastIndexOf('/') + 1);
+
+            if (fileName.isBlank()) {
+                throw new IllegalArgumentException("유효하지 않은 이미지 URL입니다(파일명이 비어 있음).");
+            }
+            if (fileName.contains(":")) {
+                throw new IllegalArgumentException("이미지 파일명에 ':' 문자는 허용되지 않습니다.");
+            }
+            return fileName;
+        }
+
+        // 이미 파일명(또는 오브젝트 키)인 경우: 간단 검증
+        if (val.contains(":")) {
+            throw new IllegalArgumentException("이미지 파일명에 ':' 문자는 허용되지 않습니다.");
+        }
+        // 앞/뒤 불필요한 '/' 제거는 하지 않음(키의 일부일 수 있으므로), 공백만 제거
         return val;
     }
 
     /**
-     * 응답용 절대경로: CloudFront 베이스 + 파일명
-     * (들어온 값이 절대 URL이든 파일명이든 결과는 CloudFront 절대경로로 통일)
+     * 응답용 절대경로: CloudFront 베이스 + 파일명/키
+     * cloudFrontBaseUrl의 슬래시 유무와 상관없이 안전하게 결합
      */
     private String toCloudFrontUrl(String fileNameOrUrl) {
         if (fileNameOrUrl == null || fileNameOrUrl.isBlank()) return null;
-        String fileName = normalizeToFileName(fileNameOrUrl);
-        // cloudFrontBaseUrl이 /로 끝나지 않는다고 가정
-        return cloudFrontBaseUrl + "/" + fileName;
+        String fileNameOrKey = normalizeToFileName(fileNameOrUrl); // blob/data 차단 포함
+        return joinUrl(cloudFrontBaseUrl, fileNameOrKey);
+    }
+
+    private String joinUrl(String base, String path) {
+        if (base.endsWith("/")) {
+            if (path.startsWith("/")) return base + path.substring(1);
+            return base + path;
+        } else {
+            if (path.startsWith("/")) return base + path;
+            return base + "/" + path;
+        }
     }
 
     @Transactional
@@ -74,7 +111,7 @@ public class FacilityService {
                 .address(dto.getAddress())
                 .location(dto.getLocation())
                 .contact(dto.getContact())
-                // 저장은 파일명만 (절대 URL이 들어와도 파일명으로 정규화)
+                // 저장은 파일명/오브젝트 키만 (절대 URL이 들어와도 정규화)
                 .imageUrl(normalizeToFileName(dto.getImageUrl()))
                 .capacity(dto.getCapacity())
                 .description(dto.getDescription())
@@ -86,7 +123,7 @@ public class FacilityService {
 
         Facility saved = facilityRepository.save(facility);
 
-        // 응답은 CloudFront 절대경로로 내려줌
+        // 응답은 CloudFront 절대경로로 통일
         return FacilityDto.builder()
                 .id(saved.getId())
                 .name(saved.getName())
@@ -145,7 +182,7 @@ public class FacilityService {
         if (dto.getAddress() != null) facility.setAddress(dto.getAddress());
         if (dto.getContact() != null) facility.setContact(dto.getContact());
         if (dto.getImageUrl() != null) {
-            // 업데이트 시에도 DB에는 파일명만 저장
+            // 업데이트 시에도 DB에는 파일명/오브젝트 키만 저장
             facility.setImageUrl(normalizeToFileName(dto.getImageUrl()));
         }
         if (dto.getCapacity() != null) facility.setCapacity(dto.getCapacity());
@@ -164,7 +201,7 @@ public class FacilityService {
             facility.setRegion(region);
         }
 
-        // 응답은 CloudFront 절대경로로 내려줌
+        // 응답은 CloudFront 절대경로로 통일
         return FacilityDto.builder()
                 .id(facility.getId())
                 .name(facility.getName())


### PR DESCRIPTION
### 변경 내용
- `normalizeToFileName` 메서드 보완
  - `blob:` / `data:` URL 차단 (요청 시 400 반환)
  - http(s) URL에서 쿼리스트링·해시 제거 후 파일명/키만 추출
  - ':' 문자가 포함된 경우 거부
- `toCloudFrontUrl` 개선
  - baseUrl과 파일명/키를 안전하게 합치도록 처리
- DB에는 항상 **파일명/키만 저장**, 응답은 CloudFront 절대경로로 통일

### 해결된 문제
- 잘못된 `blob:` 주소가 DB에 저장돼 이미지가 로드되지 않는 문제 방지
- CloudFront URL 일관성 확보 (슬래시 중복/누락 방지)