### PR TITLE
fix: set CloudWatch/Logs client region from aws.region property

### DIFF
--- a/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
+++ b/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
@@ -3,11 +3,13 @@ package com.example.moyeorak.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import lombok.extern.slf4j.Slf4j;
 
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 
+@Slf4j
 @Configuration
 public class AwsClientsConfig {
 
@@ -20,7 +22,7 @@ public class AwsClientsConfig {
         CloudWatchClient client = CloudWatchClient.builder()
                 .region(Region.of(region))
                 .build(); // 자격증명: 기본 프로바이더 체인(IAM Role/환경변수/SharedCredentials)
-        System.out.println("[CloudWatch] region=" + region);
+        log.info("[CloudWatch] region={}", region);
         return client;
     }
 
@@ -29,7 +31,7 @@ public class AwsClientsConfig {
         CloudWatchLogsClient client = CloudWatchLogsClient.builder()
                 .region(Region.of(region))
                 .build();
-        System.out.println("[CloudWatchLogs] region=" + region);
+        log.info("[CloudWatchLogs] region={}", region);
         return client;
     }
 }

--- a/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
+++ b/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
@@ -11,21 +11,25 @@ import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 @Configuration
 public class AwsClientsConfig {
 
-    // application.yml에 aws.region이 없을 때 기본값으로 ap-northeast-2 사용
+    // application.properties 에 aws.region이 없을 때 기본값으로 ap-northeast-2 사용
     @Value("${aws.region:ap-northeast-2}")
     private String region;
 
     @Bean
     public CloudWatchClient cloudWatchClient() {
-        return CloudWatchClient.builder()
+        CloudWatchClient client = CloudWatchClient.builder()
                 .region(Region.of(region))
                 .build(); // 자격증명: 기본 프로바이더 체인(IAM Role/환경변수/SharedCredentials)
+        System.out.println("[CloudWatch] region=" + region);
+        return client;
     }
 
     @Bean
     public CloudWatchLogsClient cloudWatchLogsClient() {
-        return CloudWatchLogsClient.builder()
+        CloudWatchLogsClient client = CloudWatchLogsClient.builder()
                 .region(Region.of(region))
                 .build();
+        System.out.println("[CloudWatchLogs] region=" + region);
+        return client;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@ aws.use.default-credentials=${AWS_USE_DEFAULT_CREDENTIALS:false}
 # ===============================
 # = AWS REGION (CloudWatch/Logs ?)
 # ===============================
-# ???? ???? ??? ap-northeast-2 ??? ??
+# Set AWS region to ap-northeast-2 (used for CloudWatch/Logs)
 aws.region=ap-northeast-2
 
 # ===============================

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,8 +4,6 @@ spring.application.name=moyeorak
 # = DATABASE CONNECTION SETTINGS
 # ===============================
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
-#spring.datasource.url=jdbc:mysql://localhost:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-#spring.datasource.url=jdbc:mysql://goorm-mysql.c92y0sa8e7t2.ap-northeast-2.rds.amazonaws.com:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=choi
 spring.datasource.password=1q2w3e4r!!
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -16,6 +14,12 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 aws.use.default-credentials=${AWS_USE_DEFAULT_CREDENTIALS:false}
 
 # ===============================
+# = AWS REGION (CloudWatch/Logs ?)
+# ===============================
+# ???? ???? ??? ap-northeast-2 ??? ??
+aws.region=ap-northeast-2
+
+# ===============================
 # = AWS REDIS SETTINGS
 # ===============================
 #spring.redis.host=goorm-redis.m98tqf.ng.0001.apn2.cache.amazonaws.com
@@ -23,7 +27,7 @@ aws.use.default-credentials=${AWS_USE_DEFAULT_CREDENTIALS:false}
 #spring.cache.type=redis
 
 # ===============================
-# = AWS S3 SETTINGS    =
+# = AWS S3 SETTINGS
 # ===============================
 cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
@@ -33,7 +37,7 @@ cloud.aws.stack.auto=false
 cloudfront.base-url=https://www.moyeorak.cloud/img
 
 # ===============================
-# = AWS SQS SETTINGS    =
+# = AWS SQS SETTINGS
 # ===============================
 sqs.queue.url=https://sqs.ap-northeast-2.amazonaws.com/004407157704/goorm-enrollment-sqs
 spring.cloud.aws.sqs.enabled=true


### PR DESCRIPTION
## 변경 내용
- `AwsClientsConfig` 추가
  - `CloudWatchClient`, `CloudWatchLogsClient` 생성 시 `aws.region` 프로퍼티 값을 사용하도록 수정
  - 기본값은 `ap-northeast-2`
- `application.properties`에 `aws.region` 프로퍼티 추가

## 배경
- 기존에는 CloudWatch 호출 시 리전이 고정되지 않아, IAM 정책 리전 조건과 불일치할 경우 `403 AccessDenied` 에러 발생
- 이를 해결하기 위해 클라이언트 생성 시 명시적으로 리전을 주입

## 영향 범위
- CloudWatch Metrics API (`/api/cloudwatch/metrics`)
- CloudWatch Logs Insights API (`/api/cloudwatch/logs/query`)

## 테스트
- 애플리케이션 실행 시 로그에 `[CloudWatch] region=ap-northeast-2`, `[CloudWatchLogs] region=ap-northeast-2` 출력 확인
- 로컬 및 서버에서 CloudWatch 호출 시 더 이상 리전 불일치 에러 발생하지 않음